### PR TITLE
feat: match Tact 1.3.0

### DIFF
--- a/example/example.tact
+++ b/example/example.tact
@@ -1,9 +1,11 @@
 import "@stdlib/ownable";
+primitive Int;
 
 struct SampleStruct {
     message: Int;
 }
-const GLOBAL_CONSTANT: map<Int, Name> = 5;
+
+virtual const GLOBAL_CONSTANT: map<Int, Name> = 05;
 
 @name(store_uint)
 native storeUint(s: Builder, value: Int, bits: Int): Builder;
@@ -13,7 +15,7 @@ message(0x1234) MyMessage {
 }
 
 fun globalFun(arg: String) {
-    let x: Int = 123;
+    let x: Int = 123_123;
 }
 
 trait MyTrait {
@@ -36,7 +38,7 @@ contract MyContract with MyTrait, Ownable? {
     init(owner: Address) {
         self.owner = owner;
     }
-    bounced() {}
+    bounced(msg: bounced<MyMessage>) {}
     external() {}
     receive() {}
     virtual fun overrideMe() {}

--- a/syntax/tact.vim
+++ b/syntax/tact.vim
@@ -32,6 +32,7 @@ syn match tactKeyword "\<receive(\@="
 " Statements, Operators & Keywords
 syn keyword tactStatement return
 syn keyword tactConditional if else
+syn keyword tactException try catch
 syn keyword tactRepeat while repeat do until
 syn match tactOperator "!"
 syn match tactOperator "!="
@@ -58,6 +59,7 @@ syn match tactOperator "|"
 syn match tactOperator "||"
 syn match tactOperator "&"
 syn match tactOperator "&&"
+syn match tactOperator "\^"
 syn keyword tactKeyword
     \ as const let fun native primitive public extend self with
     \ get abstract virtual override extends mutates inline initOf
@@ -169,6 +171,7 @@ hi def link tactFunction Function
 " Statements & Keywords
 hi def link tactStatement Statement
 hi def link tactConditional Conditional
+hi def link tactException Exception
 hi def link tactRepeat Repeat
 hi def link tactOperator Operator
 hi def link tactKeyword Keyword


### PR DESCRIPTION
- [x] `try...catch`
- [x] bitwise XOR `^`
- [x] `dumpStack()`, `pow2()`, `log2()`, `log()`
- [x] `StringBuilder.concat()`
- [x] `Address.toString()`
- [x] `map.isEmpty()`, `map.del()`
- [x] Struct & Message field punning  — supported without changes to tact.vim
- [x] implicit init — supported without changes to tact.vim
- [x] auto-import of `@stdlib/ownable` when `@stdlib/stoppable` is imported.
- [x] new constants from `@stdlib/reserve`
- [x] trailing commas in every list
- [x] added missing libraries: `@stdlib/dns`, `@stdlib/config`, `@stdlib/content`